### PR TITLE
Fixes issue with register command failing after running script again

### DIFF
--- a/falcon-linux-deploy.sh
+++ b/falcon-linux-deploy.sh
@@ -42,7 +42,7 @@ cs_sensor_register() {
         cs_token=--provisioning-token="${cs_falcon_token}"
         cs_falcon_args+=" $cs_token"
     fi
-    /opt/CrowdStrike/falconctl -s "${cs_falcon_args}"
+    /opt/CrowdStrike/falconctl -s -f "${cs_falcon_args}"
 }
 
 cs_sensor_restart() {


### PR DESCRIPTION
Fixes #19 by adding `-f` option to the falconctl command for setting the --cid option.