### PR TITLE
Added OS name and release capture via LSB

### DIFF
--- a/falcon-linux-deploy.sh
+++ b/falcon-linux-deploy.sh
@@ -321,8 +321,8 @@ os_version=$(
             version=$(rpm -qf /etc/redhat-release --queryformat '%{VERSION}' | sed 's/\([[:digit:]]\+\).*/\1/g')
         elif [ -f /etc/debian_version ]; then
             version=$(cat /etc/debian_version)
-	elif [ -f /usr/bin/lsb_release ]; then
-	    version=$(/usr/bin/lsb_release -r | /usr/bin/cut -f 2-)
+        elif [ -f /usr/bin/lsb_release ]; then
+            version=$(/usr/bin/lsb_release -r | /usr/bin/cut -f 2-)
         fi
     fi
     if [ -z "$version" ]; then

--- a/falcon-linux-deploy.sh
+++ b/falcon-linux-deploy.sh
@@ -319,6 +319,8 @@ os_version=$(
             version=$(rpm -qf /etc/redhat-release --queryformat '%{VERSION}' | sed 's/\([[:digit:]]\+\).*/\1/g')
         elif [ -f /etc/debian_version ]; then
             version=$(cat /etc/debian_version)
+	elif [ -f /usr/bin/lsb_release ]; then
+	    version=$(/usr/bin/lsb_release -r | /usr/bin/cut -f 2-)
         fi
     fi
     if [ -z "$version" ]; then

--- a/falcon-linux-deploy.sh
+++ b/falcon-linux-deploy.sh
@@ -302,6 +302,8 @@ os_name=$(
     if [ -z "$name" ]; then
         if lsb_release -s -i | grep -q ^RedHat; then
             name="RHEL"
+	elif [ -f /usr/bin/lsb_release ]; then
+	    name=$(/usr/bin/lsb_release -s -i)
         fi
     fi
     if [ -z "$name" ]; then

--- a/falcon-linux-deploy.sh
+++ b/falcon-linux-deploy.sh
@@ -310,7 +310,7 @@ os_name=$(
         die "Cannot recognise operating system"
     fi
 
-    echo $name
+    echo "$name"
 )
 
 os_version=$(

--- a/falcon-linux-deploy.sh
+++ b/falcon-linux-deploy.sh
@@ -83,7 +83,7 @@ cs_sensor_policy_version() {
 
     sensor_update_versions=$(echo "$sensor_update_policy" | json_value "sensor_version")
     if [ -z "$sensor_update_versions" ]; then
-	die "Could not find a sensor update policy with name: $cs_policy_name"
+        die "Could not find a sensor update policy with name: $cs_policy_name"
     fi
 
     local sensor_versions
@@ -302,8 +302,8 @@ os_name=$(
     if [ -z "$name" ]; then
         if lsb_release -s -i | grep -q ^RedHat; then
             name="RHEL"
-	elif [ -f /usr/bin/lsb_release ]; then
-	    name=$(/usr/bin/lsb_release -s -i)
+        elif [ -f /usr/bin/lsb_release ]; then
+            name=$(/usr/bin/lsb_release -s -i)
         fi
     fi
     if [ -z "$name" ]; then


### PR DESCRIPTION
Majority of Linux do have LSB package, using it to grab OS name and version can reduce the chances of failure from this script.